### PR TITLE
Add Notion order logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,4 @@ ADMIN_EMAIL=contact@lapetitevitrine.com
 # Notion API
 NOTION_TOKEN=secret_notion_token
 NOTION_DATABASE_ID=your_database_id
+NOTION_ORDER_DATABASE_ID=your_order_database_id

--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ STRIPE_WEBHOOK_SECRET=whsec_votre_secret_webhook_stripe
 RESEND_API_KEY=re_BhgXUkmc_NihnkFXk1qNSwQaKAQ8tEKG7
 FROM_EMAIL=contact@lapetitevitrine.com
 ADMIN_EMAIL=contact@lapetitevitrine.com
+
+# Notion API
+NOTION_TOKEN=secret_notion_token
+NOTION_DATABASE_ID=your_database_id

--- a/api/send-order-recap.ts
+++ b/api/send-order-recap.ts
@@ -11,7 +11,7 @@ const resend = new Resend(process.env.RESEND_API_KEY);
 
 async function sendOrderToNotion(order: any) {
   const token = process.env.NOTION_TOKEN as string | undefined;
-  const databaseId = process.env.NOTION_DATABASE_ID as string | undefined;
+  const databaseId = process.env.NOTION_ORDER_DATABASE_ID as string | undefined;
   if (!token || !databaseId) return;
 
   const name = `${order.formData?.firstName ?? ''} ${order.formData?.lastName ?? ''}`.trim();

--- a/src/components/ecommerce/EcommerceFlow.tsx
+++ b/src/components/ecommerce/EcommerceFlow.tsx
@@ -100,13 +100,21 @@ export const EcommerceFlow: React.FC<EcommerceFlowProps> = ({
         addFiles(textFiles, 'textFiles', 'textes_contenus');
         addFiles(otherFiles, 'otherFiles', 'autres_fichiers');
 
-        const buildFormData = (to: string, subject: string, html: string) => {
+        const buildFormData = (
+          to: string,
+          subject: string,
+          html: string,
+          order?: any,
+        ) => {
           const fd = new FormData();
           fd.append('to', to);
           fd.append('subject', subject);
           fd.append('html', html);
           if (cidList.length) {
             fd.append('cids', JSON.stringify(cidList));
+          }
+          if (order) {
+            fd.append('orderData', JSON.stringify(order));
           }
 
           visualFiles.forEach((f) => fd.append('visualFiles', f, f.name));
@@ -292,13 +300,22 @@ export const EcommerceFlow: React.FC<EcommerceFlowProps> = ({
         // Envoi email client avec fichiers en PJ
         await fetch('/api/send-order-recap', {
           method: 'POST',
-          body: buildFormData(formData.email, 'Votre récapitulatif de commande - La Petite Vitrine', htmlClient),
+          body: buildFormData(
+            formData.email,
+            'Votre récapitulatif de commande - La Petite Vitrine',
+            htmlClient,
+          ),
         });
 
         // Envoi email admin avec fichiers en PJ
         await fetch('/api/send-order-recap', {
           method: 'POST',
-          body: buildFormData(adminEmail, 'Nouvelle commande reçue - La Petite Vitrine', htmlAdmin),
+          body: buildFormData(
+            adminEmail,
+            'Nouvelle commande reçue - La Petite Vitrine',
+            htmlAdmin,
+            { pack, maintenance, formData, total },
+          ),
         });
 
         setEmailSent(true);


### PR DESCRIPTION
## Summary
- send order info to Notion when admin alert email is sent
- attach order data to email form data
- document Notion environment variables

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run type-check` *(fails: TS6305/TS2688 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ce33716b083258f4bdee1db5740d9